### PR TITLE
Docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+
+Compose file format 3.8을 사용하므로
+Docker Engine 19.03.0+ 필요합니다.
+
+docker-compose 설치가 필요합니다.
+
+docker-compose up 명령어로 실행 가능합니다.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.7.6
+
+RUN apt-get -y update
+RUN apt-get -y upgrade
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . .
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]

--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+python manage.py migrate
+python manage.py runserver 0.0.0.0:8000 --noreload
+bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+
+version: "3.8"
+services:
+  api_server:
+    build: backend
+    ports:
+      - "8000:8000"
+  frontend:
+    build: frontend
+    ports:
+      - "3000:3000"
+    stdin_open: true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:12.18.3
+
+COPY . .
+RUN chmod +x entrypoint.sh
+RUN yarn
+ENTRYPOINT ["./entrypoint.sh"]

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+yarn start
+bash


### PR DESCRIPTION
프로젝트 루트에서 docker-compose up 명령어를 사용해서

두 서버에서 필요로하는 의존성 패키지가 설치된 컨테이너를  실행시킬 수 있게 했습니다.